### PR TITLE
Fix typo in select.md

### DIFF
--- a/src/lib/select/select.md
+++ b/src/lib/select/select.md
@@ -53,7 +53,7 @@ In some cases that `<mat-form-field>` may use the placeholder as the label (see 
 ### Disabling the select or individual options
 
 It is possible to disable the entire select or individual options in the select by using the
-disabled property on the `<select>` or `<mat-select>` and the `<option>` or <mat-option>` elements respectively.
+disabled property on the `<select>` or `<mat-select>` and the `<option>` or `<mat-option>` elements respectively.
 
 <!-- example(select-disabled) -->
 


### PR DESCRIPTION
There is an unmatched backtick that stops the content from showing <mat-option>.

![Screenshot](https://user-images.githubusercontent.com/902870/54153499-214a5680-4416-11e9-9c09-734d731b8e13.png)
